### PR TITLE
Fix dtype handling in evaluation

### DIFF
--- a/examples/eval/eval.py
+++ b/examples/eval/eval.py
@@ -35,6 +35,7 @@ def _evaluate_dataset(model: Spiritlm, dataset: Iterable[Example], use_wandb: bo
         if sr != 16000:
             wav = torchaudio.functional.resample(wav, sr, 16000)
         wav = wav.squeeze(0)
+        wav = wav.to(dtype=torch.float32)
         outputs = model.generate(
             output_modality=OutputModality.TEXT,
             interleaved_inputs=[GenerationInput(content=wav, content_type=ContentType.SPEECH)],


### PR DESCRIPTION
## Summary
- revert tokenizer changes from previous commit
- cast audio to float32 in the evaluation loop

## Testing
- No tests run per user instruction

------
https://chatgpt.com/codex/tasks/task_e_684c3c01bb9c83238d4c6c4bf3e9980d