### PR TITLE
Add LibriSpeech ASR evaluation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,6 @@ setup(
     install_requires=_read_reqs("requirements.txt"),
     extras_require={
         "dev": ["pytest"],
-        "eval": ["pandas"],
+        "eval": ["pandas", "datasets", "jiwer"],
     },
 )

--- a/spiritlm/eval/README.md
+++ b/spiritlm/eval/README.md
@@ -90,3 +90,17 @@ python spiritlm/eval/eval_stsp.py \
 --pred_file ./data/examples/pred.jsonl
 > Accuracy: 100.00% for predictions ./data/examples/pred.jsonl
 ```
+
+## ASR Evaluation on LibriSpeech
+
+The script `predict_librispeech_asr.py` computes the Word Error Rate (WER) of
+Spirit LM on the LibriSpeech dataset from Hugging Face. It automatically
+downloads the requested split and configuration and reports the final WER.
+
+Example usage:
+
+```bash
+python spiritlm/eval/predict_librispeech_asr.py --config clean --split test
+```
+
+Use `--write_pred` to save the generated transcripts in JSONL format.

--- a/spiritlm/eval/predict_librispeech_asr.py
+++ b/spiritlm/eval/predict_librispeech_asr.py
@@ -1,0 +1,93 @@
+import argparse
+import json
+from typing import List
+
+from datasets import Audio, load_dataset
+from jiwer import wer
+from tqdm import tqdm
+from transformers import GenerationConfig, set_seed
+
+from spiritlm.model.spiritlm_model import (
+    ContentType,
+    GenerationInput,
+    OutputModality,
+    Spiritlm,
+)
+
+
+def transcribe(model: Spiritlm, audio_array) -> str:
+    out = model.generate(
+        output_modality=OutputModality.TEXT,
+        interleaved_inputs=[GenerationInput(content=audio_array, content_type=ContentType.SPEECH)],
+        generation_config=GenerationConfig(
+            temperature=0.8,
+            top_p=0.95,
+            max_new_tokens=100,
+            do_sample=True,
+        ),
+    )
+    assert len(out) == 1
+    return out[0].content.strip()
+
+
+def run(args: argparse.Namespace):
+    set_seed(args.seed)
+    ds = load_dataset(
+        "librispeech_asr",
+        args.config,
+        split=args.split,
+        trust_remote_code=True,
+    )
+    ds = ds.cast_column("audio", Audio(sampling_rate=16000))
+
+    model = Spiritlm(args.model)
+
+    references: List[str] = []
+    predictions: List[str] = []
+    for sample in tqdm(ds, desc=f"Transcribing {args.config}/{args.split}"):
+        references.append(sample["text"].strip())
+        pred = transcribe(model, sample["audio"]["array"])
+        predictions.append(pred)
+
+    error = wer(references, predictions) * 100
+    print(f"WER for {args.config}/{args.split}: {error:.2f}%")
+
+    if args.write_pred:
+        with open(args.write_pred, "w") as f:
+            for sample, pred in zip(ds, predictions):
+                f.write(json.dumps({"id": sample["id"], "pred": pred}) + "\n")
+        print(f"Predictions saved to {args.write_pred}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--config",
+        choices=["clean", "other"],
+        default="clean",
+        help="LibriSpeech configuration",
+    )
+    parser.add_argument(
+        "--split",
+        default="test",
+        help="Dataset split to evaluate",
+    )
+    parser.add_argument(
+        "--model",
+        type=str,
+        default="spirit-lm-expressive-7b",
+        help="Model name or path",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+    )
+    parser.add_argument(
+        "--write_pred",
+        type=str,
+        default=None,
+        help="Optional path to write predictions as JSONL",
+    )
+    args = parser.parse_args()
+    run(args)


### PR DESCRIPTION
## Summary
- add `predict_librispeech_asr.py` for WER computation on LibriSpeech
- document ASR evaluation in the evaluation README
- include `datasets` and `jiwer` in `eval` extras

## Testing
- `pytest -q` *(fails: FileNotFoundError for large checkpoint files)*

------
https://chatgpt.com/codex/tasks/task_e_684de602ecb8832391f8e993fba27e9a